### PR TITLE
IO benchmark: Update params and configs

### DIFF
--- a/scripts/gen/io-load.sh
+++ b/scripts/gen/io-load.sh
@@ -30,18 +30,18 @@ if [ $TEST_FILES_COUNT -ne 64 ]; then
     if [ "$CLOUD" == "gcp" ]
     then
         sudo umount /mnt/data1
-        sudo mount -o discard,defaults,nobarrier $(awk '/\/mnt\/data1/ {print $1}' /etc/mtab) /mnt/data1
+        sudo mount -o discard,defaults $(awk '/\/mnt\/data1/ {print $1}' /etc/mtab) /mnt/data1
     elif [ $CLOUD == "aws" ]
     then
         DEV=$(mount | grep /mnt/data1 | awk '{print $1}'); 
         sudo umount /mnt/data1; 
-        sudo mount -o discard,defaults,nobarrier ${DEV} /mnt/data1/; 
+        sudo mount -o discard,defaults  ${DEV} /mnt/data1/;
         mount | grep /mnt/data1
     elif [ $CLOUD == "azure" ]
     then
         DEV=$(mount | grep /mnt | awk '{print $1}');
         sudo umount /mnt;
-        sudo mount -o discard,defaults,barrier=0 ${DEV} /mnt
+        sudo mount -o discard,defaults  ${DEV} /mnt
         mount | grep /mnt
         sudo mkdir /mnt/data1
     else

--- a/scripts/gen/io-rd.sh
+++ b/scripts/gen/io-rd.sh
@@ -23,6 +23,20 @@ cd /mnt/data1
 > /mnt/data1/io-rd-results.log
 
 # Set memory to 50 Megabytes
-for each in 1 4 8 16 32 64; do sudo cgexec -g memory:group1 sysbench fileio --file-total-size=80G --file-test-mode=rndrd --time=240 --max-requests=0 --file-block-size=32K --file-num=64 --file-fsync-all --threads=$each run; sleep 10;
+for each in 1 4 8 16 32 64
+do 
+  sudo cgexec -g memory:group1   \
+    sysbench fileio              \
+    --file-total-size=80G        \
+    --file-test-mode=rndrd       \
+    --time=240                   \
+    --max-requests=0             \
+    --file-block-size=32K        \
+    --file-num=64                \
+    --file-fsync-all             \
+    --file-fsync-mode=fdatasync  \
+    --threads=$each run
+
+  sleep 10;
 done &>> /mnt/data1/io-rd-results.log
 

--- a/scripts/gen/io-wr.sh
+++ b/scripts/gen/io-wr.sh
@@ -22,5 +22,19 @@ cd /mnt/data1
 
 > /mnt/data1/io-wr-results.log
 
-for each in 1 4 8 16 32 64; do sudo cgexec -g memory:group1 sysbench fileio --file-total-size=8G --file-test-mode=rndwr --time=240 --max-requests=0 --file-block-size=32K --file-num=64 --file-fsync-all --threads=$each run; sleep 10;
+for each in 1 4 8 16 32 64
+do
+  sudo cgexec -g memory:group1   \
+    sysbench fileio              \
+    --file-total-size=80G        \
+    --file-test-mode=rndwr       \
+    --time=240                   \
+    --max-requests=0             \
+    --file-block-size=32K        \
+    --file-num=64                \
+    --file-fsync-all             \
+    --file-fsync-mode=fdatasync  \
+    --threads=$each run
+
+    sleep 10;
 done &>> /mnt/data1/io-wr-results.log


### PR DESCRIPTION
Use --file-fsync-mode=fdatasync in read and write benchmarks.
Drop nobarrie mount option since this option is deprecated.