### PR TITLE
parse/cpu: fix CPU benchmark parsing

### DIFF
--- a/scripts/parse/cpu.sh
+++ b/scripts/parse/cpu.sh
@@ -19,6 +19,6 @@ fi
 echo "uuid,bogo ops,real time (secs),usr time (secs),sys time (secs),bogo ops/s (real time), bogo ops/s (usr+sys time)" > ${CPUCSVPATH}
 
 UUID=$(cat "${DIR}/uuid.txt")
-DATA=$(pcregrep --om-separator="," -o1 -o2 -o3 -o4 -o5 -o6 'cpu\s+(\d+?)\s+(.+?)\s+(.+?)\s+(.+?)\s+(.+?)\s+(.+?)$' ${CPULOGPATH})
+DATA=$(pcregrep --om-separator="," -o1 -o2 -o3 -o4 -o5 -o6 'matrix\s+(\d+?)\s+(.+?)\s+(.+?)\s+(.+?)\s+(.+?)\s+(.+?)$' ${CPULOGPATH})
 
 echo "${UUID},${DATA}" >> ${CPUCSVPATH}


### PR DESCRIPTION
When the CPU stressor was updated, the parsing script was not updated
with it. Instead of looking for the CPU stressor, the regex should be
looking for the "matrix" stressor column.