### PR TITLE
fio: Cleanup fio generated files upon benchmark completion.

### DIFF
--- a/cloudDetails/aws.json
+++ b/cloudDetails/aws.json
@@ -26,7 +26,7 @@
       "aws-machine-type-ssd": "{{.MachineType}}",
       "aws-zones": "us-east-1a",
       "aws-image-ami": "ami-013da1cc4ae87618c",
-      "local-ssd-no-ext4-barrier": "false"
+      "local-ssd-no-ext4-barrier": null
     }
   },
   {

--- a/cloudDetails/azure.json
+++ b/cloudDetails/azure.json
@@ -16,7 +16,7 @@
     "roachprodArgs": {
       "local-ssd": null,
       "azure-locations": "eastus",
-      "local-ssd-no-ext4-barrier": "false"
+      "local-ssd-no-ext4-barrier": null
    }
   }
 ]

--- a/cloudDetails/gce.json
+++ b/cloudDetails/gce.json
@@ -17,7 +17,7 @@
             "local-ssd": null,
             "gce-image": "ubuntu-1804-bionic-v20200923",
             "gce-zones": "us-east4-b",
-            "local-ssd-no-ext4-barrier": "false"
+            "local-ssd-no-ext4-barrier": null
         }
     }
 ]

--- a/scripts/gen/fio.cfg
+++ b/scripts/gen/fio.cfg
@@ -141,31 +141,7 @@ numjobs=4
 stonewall
 
 ;
-; Random read 4KB: 16 jobs
-;
-[gen-rnd-read-4k-j16]
-include aio-fio.cfg
-rw=randread
-blocksize=4k
-numjobs=16
-stonewall
-
-[gen-rnd-read-8k-j16]
-include aio-fio.cfg
-rw=randread
-blocksize=8k
-numjobs=16
-stonewall
-
-[gen-rnd-read-16k-j16]
-include aio-fio.cfg
-rw=randread
-blocksize=16k
-numjobs=16
-stonewall
-
-;
-; Random 80%rd/20%wr 4KB: 1 job
+; Random 80%rd/20%wr: 1 job
 ;
 [gen-rnd-read-4k-j1]
 include aio-fio.cfg
@@ -192,7 +168,7 @@ numjobs=1
 stonewall
 
 ;
-; Random 80%rd/20%wr 4KB: 4 jobs
+; Random 80%rd/20%wr: 4 jobs
 ;
 [gen-rnd-read-4k-j4]
 include aio-fio.cfg
@@ -216,33 +192,6 @@ rw=randrw
 rwmixread=80
 blocksize=16k
 numjobs=4
-stonewall
-
-;
-; Random read 80%rd/20%wr: 16 jobs
-;
-[gen-rnd-read-4k-j16]
-include aio-fio.cfg
-rw=randrw
-rwmixread=80
-blocksize=4k
-numjobs=16
-stonewall
-
-[gen-rnd-read-8k-j16]
-include aio-fio.cfg
-rw=randrw
-rwmixread=80
-blocksize=8k
-numjobs=16
-stonewall
-
-[gen-rnd-read-16k-j16]
-include aio-fio.cfg
-rw=randrw
-rwmixread=80
-blocksize=16k
-numjobs=16
 stonewall
 
 ;

--- a/scripts/gen/fio.sh
+++ b/scripts/gen/fio.sh
@@ -39,7 +39,11 @@ then
   exit
 fi
 
-trap "rm -f $pidfile" EXIT SIGINT
+# Dir specifies directory to store files
+# and thus the *disk* to benchmark.
+fiodir=/mnt/data1/fio
+
+trap "rm -f $pidfile; rm -rf $fiodir" EXIT SIGINT
 echo $$ > "$pidfile"
 
 # Remove processed options.  Remaining ones assumed to be FIO specific flags.
@@ -53,10 +57,6 @@ exec &> >(tee -a "$logdir/script.log")
 # Dump lsblk and df information (to make sure we have the right disks)
 lsblk
 df -h
-
-# Dir specifies directory to store files
-# and thus the *disk* to benchmark.
-fiodir=/mnt/data1/fio
 
 # Uncomment if you want to regenerate test files.
 # rm -rf /mnt/data1/fio


### PR DESCRIPTION
Pair down fio benchmarks.
Update cloud configurations:
  * Use correct flag value to disable 'nobarrier'
  * Make it possible to run multiple stores on AWS