### PR TITLE
Benchmark fixes:

### DIFF
--- a/cloudDetails/azure.json
+++ b/cloudDetails/azure.json
@@ -36,7 +36,9 @@
       "local-ssd": "false",
       "azure-network-disk-type": "premium-disk",
       "azure-locations": "eastus",
-      "azure-availability-zone": "2"
+      "azure-availability-zone": "2",
+      "azure-volume-size": "2500",
+      "azure-disk-caching": "read-only"
     }
   },
   {
@@ -57,7 +59,8 @@
       "local-ssd": "false",
       "azure-network-disk-type": "ultra-disk",
       "azure-locations": "eastus",
-      "azure-availability-zone": "2"
+      "azure-availability-zone": "2",
+      "azure-volume-size": "2500"
     }
   }
 ]

--- a/cloudDetails/cc.json
+++ b/cloudDetails/cc.json
@@ -1,0 +1,59 @@
+[
+  {
+    "group": "ebs-io2",
+    "cloud": "aws",
+    "machineTypes": {
+      "c5.large": {
+        "args": {
+          "aws-ebs-volume-size": "60",
+          "aws-ebs-iops": "600"
+        },
+        "tpcc": {
+          "cost_descr": "CostPerMonth=(Instance: 0.085 * 24 * 30) + (Disk: 60*0.125) + (IOPs: 600*0.065)",
+          "cost": 107.7,
+          "warehouses": 500
+        }
+      },
+      "c5.2xlarge": {
+        "args": {
+        "aws-ebs-volume-size": "150",
+        "aws-ebs-iops": "900"
+        },
+        "tpcc": {
+          "cost_descr": "CostPerMonth=(Instance: 0.17 * 24 * 30) + (Disk: 150*0.125) + (IOPs: 900*0.065)",
+          "cost": 199.65,
+          "warehouses": 750
+        }
+      },
+      "c5.2xlarge": {
+        "args": {
+          "aws-ebs-volume-size": "500",
+          "aws-ebs-iops": "1800"
+        },
+        "tpcc": {
+          "cost_descr": "CostPerMonth=(Instance: 0.34 * 24 * 30) + (Disk: 500*0.125) + (IOPs: 1800*0.065)",
+          "cost": 424.3,
+          "warehouses": 1125
+        }
+      },
+      "c5.4xlarge": {
+        "args": {
+          "aws-ebs-volume-size": "900",
+          "aws-ebs-iops": "2000"
+        },
+        "tpcc": {
+          "cost_descr": "CostPerMonth=(Instance: 0.68 * 24 * 30) + (Disk: 900*0.125) + (IOPs: 2000*0.065)",
+          "cost": 732.1,
+          "warehouses": 1700
+        }
+      }
+    },
+    "roachprodArgs" : {
+      "aws-ebs-volume-type": "io2",
+      "aws-zones": "us-east-1a",
+      "aws-image-ami": "ami-013da1cc4ae87618c",
+      "local-ssd": "false",
+      "aws-enable-multiple-stores": null
+    }
+  }
+]

--- a/scripts/gen/fio.sh
+++ b/scripts/gen/fio.sh
@@ -44,11 +44,17 @@ fi
 # !!! WARNING !!!
 #    THIS WILL DESTROY DATA ON THE DISK ***
 # !!! WARNING !!!
-DEV=$(lsblk | grep /mnt/data1|cut -d" " -f1)
+if mountpoint -q /mnt/data1;
+then
+  mount=$(readlink /mnt/data1 || echo /mnt/data1)
+else
+  mount="/mnt"
+fi
+DEV=$(lsblk -r | grep $mount|cut -d" " -f1)
 
 # Unmount /mnt/data1 -- the disk we will benchmark; remount when benchmark completes.
-sudo umount /mnt/data1
-trap "rm -f $pidfile; sudo mkfs.ext4 -F /dev/$DEV && sudo mount /mnt/data1" EXIT SIGINT
+sudo umount "$mount"
+trap "rm -f $pidfile; sudo mkfs.ext4 -F /dev/$DEV && sudo mount $mount" EXIT SIGINT
 echo $$ > "$pidfile"
 
 # Remove processed options.  Remaining ones assumed to be FIO specific flags.


### PR DESCRIPTION
* Fix FIO benchmark for Azure
* Add disk size and disk caching flags for azure.
* Update generated scripts *not* to start cockroach when running with `-b all`
  Move cockroach startup to TPCC benchmark (otherwise, this breaks FIO
  benchmark which needs to unmount data disk).