### PR TITLE
Add cross-region network test

### DIFF
--- a/cloudDetails/aws.json
+++ b/cloudDetails/aws.json
@@ -1,73 +1,27 @@
 [
   {
-    "group": "local-ssd",
-    "cloud": "aws",
-    "machineTypes": {
-      "m5d.4xlarge": null,
-      "m5dn.4xlarge": null,
-      "m5ad.4xlarge": null,
-      "m6gd.4xlarge": {
-        "roachprodArgs": {
-          "aws-image-ami": "ami-09bc3af312d0310c2"
-        }
-      },
-      "c6gd.4xlarge": {
-        "roachprodArgs": {
-          "aws-image-ami": "ami-09bc3af312d0310c2"
-        }
-      },
-      "c5d.4xlarge": null,
-      "r5d.4xlarge": null,
-      "r5dn.4xlarge": null,
-      "r5ad.4xlarge": null,
-      "i3.4xlarge": null,
-      "i3en.6xlarge": {
-        "roachprodArgs" : {
-          "aws-cpu-options": "CoreCount=8,ThreadsPerCore=2"
-        }
-      }
-    },
-    "roachprodArgs": {
-      "local-ssd": null,
-      "aws-machine-type-ssd": "{{.MachineType}}",
-      "aws-zones": "us-east-1a",
-      "aws-image-ami": "ami-089b5711e63812c2a",
-      "local-ssd-no-ext4-barrier": "false",
-      "aws-enable-multiple-stores": null
-    },
-    "benchArgs": {
-      "io": "-s"
-    }
-  },
-  {
     "group": "ebs-gp2",
     "cloud": "aws",
     "machineTypes": {
-      "m5.4xlarge": null,
-      "m5n.4xlarge": null,
-      "m5a.4xlarge": null,
-      "m6g.4xlarge": {
-        "roachprodArgs": {
-          "aws-image-ami": "ami-09bc3af312d0310c2"
-        }
-      },
-      "c6g.4xlarge": {
-        "roachprodArgs": {
-          "aws-image-ami": "ami-09bc3af312d0310c2"
-        }
-      },
-      "c5n.4xlarge": null,
-      "c5a.4xlarge": null,
-      "x1e.4xlarge": null,
-      "r5.4xlarge": null,
-      "r5n.4xlarge": null,
-      "r5a.4xlarge": null
+      "m6i.2xlarge": null,
+      "m5a.2xlarge": null,
+      "m5n.2xlarge": null,
+      "m5.2xlarge": null,
+      "c5a.2xlarge": null,
+      "c5.2xlarge": null,
+      "c5n.2xlarge": null,
+      "r5a.2xlarge": null,
+      "r5.2xlarge": null,
+      "r5b.2xlarge": null,
+      "r5n.2xlarge": null
     },
     "roachprodArgs" : {
       "aws-ebs-volume-type": "gp2",
       "aws-ebs-volume-size": "2500",
       "aws-zones": "us-east-1a",
+      "west-aws-zones": "us-west-2a",
       "aws-image-ami": "ami-036490d46656c4818",
+      "west-aws-image-ami": "ami-0964546d3da97e3ab",
       "local-ssd": "false",
       "aws-enable-multiple-stores": null
     }
@@ -76,31 +30,25 @@
     "group": "ebs-io2",
     "cloud": "aws",
     "machineTypes": {
-      "m5.4xlarge": null,
-      "m5n.4xlarge": null,
-      "m5a.4xlarge": null,
-      "m6g.4xlarge": {
-        "roachprodArgs": {
-          "aws-image-ami": "ami-09bc3af312d0310c2"
-        }
-      },
-      "c6g.4xlarge": {
-        "roachprodArgs": {
-          "aws-image-ami": "ami-09bc3af312d0310c2"
-        }
-      },
-      "c5n.4xlarge": null,
-      "c5a.4xlarge": null,
-      "x1e.4xlarge": null,
-      "r5.4xlarge": null,
-      "r5n.4xlarge": null,
-      "r5a.4xlarge": null
+      "m6i.2xlarge": null,
+      "m5a.2xlarge": null,
+      "m5n.2xlarge": null,
+      "m5.2xlarge": null,
+      "c5a.2xlarge": null,
+      "c5.2xlarge": null,
+      "c5n.2xlarge": null,
+      "r5a.2xlarge": null,
+      "r5.2xlarge": null,
+      "r5b.2xlarge": null,
+      "r5n.2xlarge": null
     },
     "roachprodArgs" : {
       "aws-ebs-volume-type": "io2",
       "aws-ebs-volume-size": "2500",
       "aws-zones": "us-east-1a",
+      "west-aws-zones": "us-west-2a",
       "aws-image-ami": "ami-036490d46656c4818",
+      "west-aws-image-ami": "ami-0964546d3da97e3ab",
       "local-ssd": "false",
       "aws-ebs-iops": "16000",
       "aws-enable-multiple-stores": null

--- a/cloudDetails/azure.json
+++ b/cloudDetails/azure.json
@@ -1,44 +1,23 @@
 [
   {
-    "group": "local-ssd",
-    "cloud": "azure",
-    "machineTypes": {
-      "Standard_D16ds_v4": null,
-      "Standard_D16as_v4": null,
-      "Standard_F16s_v2": null,
-      "Standard_E16ds_v4": null,
-      "Standard_E16as_v4":  null,
-      "Standard_L16s_v2": null,
-      "Standard_M16ms": null
-    },
-    "roachprodArgs": {
-      "local-ssd": "true",
-      "azure-locations": "eastus",
-      "azure-availability-zone": "2",
-      "local-ssd-no-ext4-barrier": "false"
-    },
-    "benchArgs": {
-      "io": "-s"
-    }
-  },
-  {
     "group": "premium-disk",
     "cloud": "azure",
     "machineTypes": {
-      "Standard_D16s_v4": null,
-      "Standard_D16ds_v4": null,
-      "Standard_D16as_v4": null,
-      "Standard_F16s_v2": null,
-      "Standard_E16s_v4": null,
-      "Standard_E16ds_v4": null,
-      "Standard_E16as_v4":  null,
-      "Standard_L16s_v2": null,
-      "Standard_M16ms": null
+      "Standard_D8ds_v4": null,
+      "Standard_D8ds_v5": null,
+      "Standard_D8as_v4": null,
+      "Standard_F8sv_v2": null,
+      "Standard_E8s_v4": null,
+      "Standard_E8s_v5": null,
+      "Standard_E8ds_v4": null,
+      "Standard_E8ds_v5": null,
+      "Standard_E8as_v4": null
     },
     "roachprodArgs": {
       "local-ssd": "false",
       "azure-network-disk-type": "premium-disk",
       "azure-locations": "eastus",
+      "west-azure-locations": "westus2",
       "azure-availability-zone": "2",
       "azure-volume-size": "2500",
       "azure-disk-caching": "read-only"
@@ -48,20 +27,21 @@
     "group": "ultra-disk",
     "cloud": "azure",
     "machineTypes": {
-      "Standard_D16s_v4": null,
-      "Standard_D16ds_v4": null,
-      "Standard_D16as_v4": null,
-      "Standard_F16s_v2": null,
-      "Standard_E16s_v4": null,
-      "Standard_E16ds_v4": null,
-      "Standard_E16as_v4":  null,
-      "Standard_L16s_v2": null,
-      "Standard_M16ms": null
+      "Standard_D8ds_v4": null,
+      "Standard_D8ds_v5": null,
+      "Standard_D8as_v4": null,
+      "Standard_F8sv_v2": null,
+      "Standard_E8s_v4": null,
+      "Standard_E8s_v5": null,
+      "Standard_E8ds_v4": null,
+      "Standard_E8ds_v5": null,
+      "Standard_E8as_v4": null
     },
     "roachprodArgs": {
       "local-ssd": "false",
       "azure-network-disk-type": "ultra-disk",
       "azure-locations": "eastus",
+      "west-azure-locations": "westus2",
       "azure-availability-zone": "2",
       "azure-volume-size": "2500",
 	  "azure-ultra-disk-iops": "16000"

--- a/cloudDetails/gce.json
+++ b/cloudDetails/gce.json
@@ -1,71 +1,77 @@
 [
     {
-        "group": "local-ssd",
-        "cloud": "gce",
-        "machineTypes": {
-            "n2-standard-16": null,
-            "n2d-standard-16": {
-                "roachprodArgs": {
-                    "gce-zones": "us-east1-c"
-                }
-            },
-            "n2-highmem-16": null,
-            "n2-highcpu-16": null,
-            "n2d-highcpu-16": {
-                "roachprodArgs": {
-                    "gce-zones": "us-east1-c"
-                }
-            },
-            "c2-standard-16": null,
-            "m1-ultramem-40":  null,
-            "n2-highmem-16":  null,
-            "n2d-highmem-16": {
-                "roachprodArgs": {
-                    "gce-zones": "us-east1-c"
-                }
-            }
-        },
-        "roachprodArgs": {
-            "local-ssd": null,
-            "gce-image": "ubuntu-2004-focal-v20210927",
-            "gce-zones": "us-east4-c",
-            "local-ssd-no-ext4-barrier": "false"
-        },
-        "benchArgs": {
-            "io": "-s"
-        }
-    },
-    {
         "group": "pd-ssd",
         "cloud": "gce",
         "machineTypes": {
-            "n2-standard-16": null,
-            "n2d-standard-16":  {
+            "n2-standard-8": null,
+            "n2d-standard-8":  {
                 "roachprodArgs": {
-                    "gce-zones": "us-east1-c"
+                    "gce-zones": "us-east1-c",
+                    "west-gce-zones": "us-west1-a"
                 }
             },
-            "n2-highmem-16": null,
-            "n2-highcpu-16": null,
-            "n2d-highcpu-16":  {
+
+            "n2-highcpu-8": null,
+            "n2d-highcpu-8":  {
                 "roachprodArgs": {
-                    "gce-zones": "us-east1-c"
+                    "gce-zones": "us-east1-c",
+                    "west-gce-zones": "us-west1-a"
                 }
             },
-            "c2-standard-16": null,
-            "m1-ultramem-40":  null,
-            "n2-highmem-16":  null,
-            "n2d-highmem-16": {
+            "c2-standard-8": null,
+            "n2-highmem-8": null,
+            "n2d-highmem-8": {
                 "roachprodArgs": {
-                    "gce-zones": "us-east1-c"
+                    "gce-zones": "us-east1-c",
+                    "west-gce-zones": "us-west1-a"
                 }
             }
         },
         "roachprodArgs": {
             "local-ssd": "false",
             "gce-image": "ubuntu-2004-focal-v20210927",
+            "west-gce-image": "ubuntu-2004-focal-v20210927",
             "gce-zones": "us-east4-c",
+            "west-gce-zones": "us-west1-a",
             "gce-pd-volume-type": "pd-ssd",
+            "gce-pd-volume-size": "2500"
+        }
+    },
+    {
+        "group": "pd-extreme",
+        "cloud": "gce",
+        "machineTypes": {
+            "n2-standard-8": null,
+            "n2d-standard-8":  {
+                "roachprodArgs": {
+                    "gce-zones": "us-east1-c",
+                    "west-gce-zones": "us-west1-a"
+                }
+            },
+
+            "n2-highcpu-8": null,
+            "n2d-highcpu-8":  {
+                "roachprodArgs": {
+                    "gce-zones": "us-east1-c",
+                    "west-gce-zones": "us-west1-a"
+                }
+            },
+            "c2-standard-8": null,
+            "n2-highmem-8": null,
+            "n2d-highmem-8": {
+                "roachprodArgs": {
+                    "gce-zones": "us-east1-c",
+                    "west-gce-zones": "us-west1-a"
+                }
+            }
+        },
+        "roachprodArgs": {
+            "local-ssd": "false",
+            "gce-image": "ubuntu-2004-focal-v20210927",
+            "west-gce-image": "ubuntu-2004-focal-v20210927",
+            "gce-zones": "us-east4-c",
+            "west-gce-zones": "us-west1-a",
+            "gce-pd-volume-type": "pd-extreme",
             "gce-pd-volume-size": "2500"
         }
     }


### PR DESCRIPTION
This commit uses the netperf TPC_RR and OMNI tests
to test latency and throughput
between two nodes in us-east and us-west region.
The parameters are the same as the 2021 network test.

Also re-configed the cloud details to fit the 2022 plan.