### PR TITLE
fix gce.json for n2, t2d's cpu platform and n2-custom's memory size

### DIFF
--- a/cloudDetails/gce.json
+++ b/cloudDetails/gce.json
@@ -5,10 +5,28 @@
         "machineTypes": {
             "n2-standard-8": {
                 "roachprodArgs": {
-                    "gce-pd-volume-size": "1000"
+                    "gce-min-cpu-platform": "Intel Ice Lake",
+                    "gce-zones": "us-central1-c"
                 }
             },
-            "n2-standard-32": null,
+            "n2-standard-32": {
+                "roachprodArgs": {
+                    "gce-min-cpu-platform": "Intel Ice Lake",
+                    "gce-zones": "us-central1-c"
+                }
+            },
+            "t2d-standard-8": {
+                "roachprodArgs": {
+                    "gce-min-cpu-platform": "Intel Ice Lake",
+                    "gce-zones": "us-central1-c"
+                }
+            },
+            "t2d-standard-32": {
+                "roachprodArgs": {
+                    "gce-min-cpu-platform": "Intel Ice Lake",
+                    "gce-zones": "us-central1-c"
+                }
+            },
             "n2d-standard-8":  {
                 "roachprodArgs": {
                     "gce-pd-volume-size": "1000",
@@ -66,12 +84,12 @@
                 }
             },
 
-            "n2-custom-8-32768": {
+            "n2-custom-8-16384": {
                 "roachprodArgs": {
                     "gce-pd-volume-size": "1000"
                 }
             },
-            "n2-custom-32-131072": null
+            "n2-custom-32-65536": null
         },
         "roachprodArgs": {
             "local-ssd": "false",
@@ -93,10 +111,28 @@
         "machineTypes": {
             "n2-standard-8": {
                 "roachprodArgs": {
-                    "gce-pd-volume-size": "1000"
+                    "gce-min-cpu-platform": "Intel Ice Lake",
+                    "gce-zones": "us-central1-c"
                 }
             },
-            "n2-standard-32": null,
+            "n2-standard-32": {
+                "roachprodArgs": {
+                    "gce-min-cpu-platform": "Intel Ice Lake",
+                    "gce-zones": "us-central1-c"
+                }
+            },
+            "t2d-standard-8": {
+                "roachprodArgs": {
+                    "gce-min-cpu-platform": "Intel Ice Lake",
+                    "gce-zones": "us-central1-c"
+                }
+            },
+            "t2d-standard-32": {
+                "roachprodArgs": {
+                    "gce-min-cpu-platform": "Intel Ice Lake",
+                    "gce-zones": "us-central1-c"
+                }
+            },
             "n2d-standard-8": {
                 "roachprodArgs": {
                     "gce-pd-volume-size": "1000",
@@ -148,12 +184,12 @@
                     "gce-min-cpu-platform": "AMD Milan"
                 }
             },
-            "n2-custom-8-32768": {
+            "n2-custom-8-16384": {
                 "roachprodArgs": {
                     "gce-pd-volume-size": "1000"
                 }
             },
-            "n2-custom-32-131072": null
+            "n2-custom-32-65536": null
         },
         "roachprodArgs": {
             "local-ssd": "false",

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -107,6 +107,8 @@ function create_cluster() {
 
   roachprod run "$CLUSTER" -- tmux new -s "$TMUX_SESSION" -d
   roachprod run "$CLUSTER" -- tmux set-option remain-on-exit on
+
+  roachprod run "$CLUSTER":1 -- sudo lshw -c memory > "$logdir"/"$CLUSTER"_ram_info.txt
 }
 
 # Create roachprod in us-west2


### PR DESCRIPTION
Added cpu min platform and location setting for n2 and t2d.
The n2-standard and t2d-standard were run with Intel Ice Lake at us-central-1.

Updated the tested n2-custom machines' memory setting to "2 GB ram to 1 vCPU".